### PR TITLE
add CA region and CA lab filters to CA build

### DIFF
--- a/profiles/czbiohub/ca_auspice_config.json
+++ b/profiles/czbiohub/ca_auspice_config.json
@@ -1,0 +1,147 @@
+{
+  "title": "Genomic epidemiology of novel coronavirus",
+  "build_url": "https://github.com/nextstrain/ncov",
+  "maintainers": [
+    {"name": "Chan Zuckerberg Biohub",
+     "url": "https://www.czbiohub.org"}
+  ],
+  "colorings": [
+    {
+      "key": "legacy_clade_membership",
+      "title": "Old Nextstrain clade",
+      "type": "categorical"
+    },
+    {
+      "key": "pangolin_lineage",
+      "title": "Pangolin lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "county",
+      "title": "County",
+      "type": "categorical"
+    },
+    {
+      "key": "CA_region",
+      "title": "CA region",
+      "type": "categorical"
+    },
+    {
+      "key": "CA_lab",
+      "title": "CA submitting lab",
+      "type": "categorical"
+    },
+    {
+      "key": "location",
+      "title": "Location",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Admin Division",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "age",
+      "title": "Age",
+      "type": "continuous"
+    },
+    {
+      "key": "sex",
+      "title": "Sex",
+      "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "gisaid_epi_isl",
+      "type": "categorical"
+    },
+    {
+      "key": "genbank_accession",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "county",
+    "location",
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "color_by": "county",
+    "distance_measure": "div",
+    "geo_resolution": "location",
+    "map_triplicate": false,
+    "branch_label": "clade"
+  },
+  "filters": [
+    "county",
+    "CA_region",
+    "CA_lab",
+    "recency",
+    "clade_membership",
+    "region",
+    "country",
+    "division",
+    "location",
+    "host",
+    "submitting_lab",
+    "originating_lab",
+    "author"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy"
+  ]
+}


### PR DESCRIPTION
This adds `CA_region` and `CA_lab` as filters if the metadata columns are available.